### PR TITLE
Avoid trap in MYSQLND_METHOD(mysqlnd_conn, close) when called by dest…

### DIFF
--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -2438,7 +2438,25 @@ MYSQLND_METHOD(mysqlnd_conn, close)(MYSQLND * conn_handle, const enum_connection
 				STAT_CLOSE_IMPLICIT,
 				STAT_CLOSE_DISCONNECT
 			};
+#ifndef __OS2__
 			MYSQLND_INC_CONN_STATISTIC(conn->stats, close_type_to_stat_map[close_type]);
+#else
+			/* We can get here via a destructor callback if php terminates
+			   before the runtime environment is fully initialized.
+			   When this occurs, we may not have a valid pointer to mysqlnd_globals_id
+			   and we need to bypass the statistics update to avoid trapping.
+			   If this code path is possible on other platforms, this is an upstream defect.
+			   Warn if ZEND_ENABLE_STATIC_TSRMLS_CACHE not defined because
+			   ZEND_MODULE_GLOBALS_POINTER depends on this.
+			   2022-05-25 SHL hack cough
+			*/
+#ifndef ZEND_ENABLE_STATIC_TSRMLS_CACHE
+#warning Expected ZEND_ENABLE_STATIC_TSRMLS_CACHE to be defined
+#endif
+			#define ZEND_MODULE_GLOBALS_POINTER(module_name) TSRMG_BULK_STATIC(module_name##_globals_id, zend_##module_name##_globals *)
+			if (ZEND_MODULE_GLOBALS_POINTER(mysqlnd) != NULL)
+				MYSQLND_INC_CONN_STATISTIC(conn->stats, close_type_to_stat_map[close_type]);
+#endif
 		}
 
 		/*


### PR DESCRIPTION
…ructor callback for early connection failure that occurs before connection data fully initialized.

Resolves ticket #760.