### PR TITLE
Show failcnt when reporting zend_mm_mmap out of memory.

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -507,9 +507,11 @@ static void *zend_mm_mmap(size_t size)
 		char szTimestamp[28];
 		formatTimestamp(szTimestamp);
 		failcnt++;
-		fprintf(stderr, "\n%s zend_mm_mmap mmap(NULL, 0x%x) failed pid:%u (%x) tid:%u%s [%d] %s\n",
-			 szTimestamp, size, pid, pid, _gettid(),
-			 failcnt >= 3 ? " - exiting" : "", errno, strerror(errno));
+		fprintf(stderr, "\n%s zend_mm_mmap mmap(NULL, 0x%x) failed pid:%u (%x) tid:%u cnt:%d%s [%d] %s\n",
+			szTimestamp, size, pid, pid, _gettid(),
+			failcnt,
+			failcnt >= 3 ? " - exiting" : "",
+			errno, strerror(errno));
 		/* Once we get here we need to die if we are recursing */
 		if (failcnt >= 3)
 			exit(1);

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -475,6 +475,7 @@ static void *zend_mm_mmap(size_t size)
 {
 #ifdef __OS2__	/* 2022-07-01 SHL */
 	static int failcnt;
+	static int failtid;
 #endif
 #ifdef _WIN32
 	void *ptr = VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -503,12 +504,14 @@ static void *zend_mm_mmap(size_t size)
 	if (ptr == MAP_FAILED) {
 #if ZEND_MM_ERROR
 #ifdef __OS2__	/* 2022-07-01 SHL */
-		pid_t pid = _getpid();
+		pid_t pid;
 		char szTimestamp[28];
-		formatTimestamp(szTimestamp);
+		failtid = _gettid();
 		failcnt++;
+		pid = _getpid();
+		formatTimestamp(szTimestamp);
 		fprintf(stderr, "\n%s zend_mm_mmap mmap(NULL, 0x%x) failed pid:%u (%x) tid:%u cnt:%d%s [%d] %s\n",
-			szTimestamp, size, pid, pid, _gettid(),
+			szTimestamp, size, pid, pid, failtid,
 			failcnt,
 			failcnt >= 3 ? " - exiting" : "",
 			errno, strerror(errno));
@@ -524,7 +527,7 @@ static void *zend_mm_mmap(size_t size)
 	}
 #if ZEND_MM_ERROR
 #ifdef __OS2__	/* 2022-07-01 SHL */
-	else {
+	else if (failcnt > 0 && failtid == _gettid()) {
 		failcnt = 0;		/* Recovered */
 	 }
 #endif


### PR DESCRIPTION
For some as yet unknown reason, it appears that exit() is not exiting the process.  Odd.