### PR TITLE
Rework BEGINLIBPATH value reporting.

### DIFF
--- a/ext/standard/dl.c
+++ b/ext/standard/dl.c
@@ -181,11 +181,8 @@ static void update_beginlibpath(const char *extension_dir)
 	if (apiret != 0) {
 		php_error_docref(NULL, E_ERROR,
 				"update_beginlibpath DosSetExtLIBPATH failed with error %lu", apiret);
-		return;
 	}
 
-	php_error_docref(NULL, E_NOTICE,
-			 "update_beginlibpath set BEGINLIBPATH to %s", beginlibpath);
 	return;
 }
 #endif // __OS2__


### PR DESCRIPTION
Drop from update_beginlibpath() - someone complained.
Report in php_print_info as environment variable if set - better matches OS/2 semantics.