### PR TITLE
Revert failed zend_try experiment. It does not avoid the exceptions.

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -3484,25 +3484,21 @@ static void php_putenv_destructor(zval *zv) /* {{{ */
 	} else {
 # if HAVE_UNSETENV
 #ifdef __OS2__
-		/* 2023-02-02 SHL Avoid death if called with pe->key pointing to uncommitted memory.
-		   We do not yet know how the memory became uncommitted.
-		   Someday, we might.
-		   The pointer looks as if it was valid at one time.
-		   This seems to happen only during php_request_shutdown processing.
-		   To avoid the trap we wrap the code in a zend_try.
-		*/
-		zend_try {
+		    /* 2023-02-02 SHL Avoid death if called with pe->key pointing to uncommitted memory.
+		       We do not yet know how the memory became uncommitted.
+		       The pointer looks as if it was valid at one time.
+		       This seems to happen only during php_request_shutdown processing.
+		       To avoid the trap we wrap the code in a zend_try.
+		    */
+		    zend_try {
 #endif
 		unsetenv(pe->key);
 #ifdef __OS2__
-		} zend_catch {
-			// Try to report with zend_error in case we have file and line number
-			zend_try {
-				zend_error(E_WARNING, "php_putenv_destructor pe->key %p points to uncommitted memory (%u)\n", pe->key, __LINE__);
-			} zend_catch {
-				fprintf(stderr, "php_putenv_destructor unsetenv(pe->key) %p points to uncommitted memory (%u)\n", pe->key, __LINE__);
-			} zend_end_try();
-		} zend_end_try();
+		    } zend_catch {
+			    fprintf(stderr, "php_putenv_destructor unsetenv(pe->key) %p points to uncommitted memory (%u)\n", pe->key, __LINE__);
+			    // Try to report with zend_error - can fail - FIXME to be gone
+			    zend_error(E_NOTICE, "php_putenv_destructor pe->key %p points to uncommitted memory\n", pe->key);
+		    } zend_end_try();
 #endif
 
 # elif defined(PHP_WIN32)
@@ -3515,26 +3511,22 @@ static void php_putenv_destructor(zval *zv) /* {{{ */
 
 		for (env = environ; env != NULL && *env != NULL; env++) {
 #ifdef __OS2__
-			/* 2023-02-02 SHL Avoid death if called with pe->key pointing to uncommitted memory.
-			   We do not yet know how the memory became uncommitted.
-			   The pointer looks as if it was valid at one time.
-			   This seems to happen only during php_request_shutdown processing.
-			   To avoid the trap we wrap the code in a zend_try.
-			*/
-			zend_try {
+		    /* 2023-02-02 SHL Avoid death if called with pe->key pointing to uncommitted memory.
+		       We do not yet know how the memory became uncommitted.
+		       The pointer looks as if it was valid at one time.
+		       This seems to happen only during php_request_shutdown processing.
+		       To avoid the trap we wrap the code in a zend_try.
+		    */
+		    zend_try {
 #endif
 			if (!strncmp(*env, pe->key, pe->key_len) && (*env)[pe->key_len] == '=') {	/* found it */
 				*env = "";
 				break;
 			}
 #ifdef __OS2__
-			} zend_catch {
-				zend_try {
-					zend_error(E_WARNING, "php_putenv_destructor pe->key %p points to uncommitted memory (%u)\n", pe->key, __LINE__);
-				} zend_catch {
-					fprintf(stderr, "php_putenv_destructor pe->key %p points to uncommitted memory (%u)\n", pe->key, __LINE__);
-				} zend_end_try();
-			} zend_end_try();
+		    } zend_catch {
+			    fprintf(stderr, "php_putenv_destructor pe->key %p points to uncommitted memory (%u)\n", pe->key, __LINE__);
+		    } zend_end_try();
 #endif
 		}
 # endif
@@ -3549,7 +3541,7 @@ static void php_putenv_destructor(zval *zv) /* {{{ */
 	   This seems to happen only during php_request_shutdown processing.
 	   To avoid the trap we wrap the strncmp call in a zend_try.
 	*/
-
+	  
 #ifdef __OS2__
 	zend_try {
 #endif
@@ -3558,11 +3550,7 @@ static void php_putenv_destructor(zval *zv) /* {{{ */
 	}
 #ifdef __OS2__
 	} zend_catch {
-		zend_try {
-			zend_error(E_WARNING, "php_putenv_destructor pe->key %p points to uncommitted memory (%u)\n", pe->key, __LINE__);
-		} zend_catch {
-			fprintf(stderr, "php_putenv_destructor pe->key %p points to uncommitted memory (%u)\n", pe->key, __LINE__);
-		} zend_end_try();
+		fprintf(stderr, "php_putenv_destructor pe->key %p points to uncommitted memory (%u)\n", pe->key, __LINE__);
 	} zend_end_try();
 #endif
 

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -3503,27 +3503,9 @@ static void php_putenv_destructor(zval *zv) /* {{{ */
 #ifdef HAVE_TZSET
 	/* don't forget to reset the various libc globals that
 	 * we might have changed by an earlier call to tzset(). */
-
-	/* 2023-01-30 SHL Avoid death if called with pe->key pointing to uncommitted memory.
-	   We do not yet know how the memory became uncommitted.
-	   The pointer looks as if it was valid at one time.
-	   This seems to happen only during php_request_shutdown processing.
-	   To avoid the trap we wrap the strncmp call in a zend_try.
-	*/
-	  
-#ifndef __OS2__
 	if (!strncmp(pe->key, "TZ", pe->key_len)) {
 		tzset();
 	}
-#else // __OS2__
-	zend_try {
-		if (!strncmp(pe->key, "TZ", pe->key_len))
-			tzset();
-	} zend_catch {
-		fprintf(stderr, "php_putenv_destructor pe->key %p points to uncommitted memory\n", pe->key);
-	} zend_end_try();
-#endif
-
 #endif
 
 	efree(pe->putenv_string);
@@ -4165,7 +4147,7 @@ PHP_FUNCTION(getenv)
     tsrm_env_unlock();
 
     if (ptr) {
-	return;
+        return;
     }
 
 #endif
@@ -5749,9 +5731,9 @@ PHP_FUNCTION(getservbyname)
 
 #if defined(_AIX)
 	/*
-	On AIX, imap is only known as imap2 in /etc/services, while on Linux imap is an alias for imap2.
-	If a request for imap gives no result, we try again with imap2.
-	*/
+        On AIX, imap is only known as imap2 in /etc/services, while on Linux imap is an alias for imap2.
+        If a request for imap gives no result, we try again with imap2.
+        */
 	if (serv == NULL && strcmp(name,  "imap") == 0) {
 		serv = getservbyname("imap2", proto);
 	}

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -673,29 +673,7 @@ normal:
 		r->subprocess_env != r->main->subprocess_env
 	) {
 		/* setup standard CGI variables */
-#ifdef		__OS2__
-		/* 2023-02-04 SHL Fail nicely if we trap in ap_add_common_vars
-		   The actual trap is in add_unless_null and occurs for as
-		   yet unknown reasons.
-		   add_unless_null logs the exception and then reflects
-		   it here so that the request can be failed upstream.
-		   If we ever figure out why, this code can go away.
-		*/
-		zend_try {
-#endif
 		ap_add_common_vars(r);
-#ifdef		__OS2__
-                }
-		zend_catch {
-			zend_try {
-				zend_error(E_ERROR, "ap_add_common_vars trapped (%u)\n",  __LINE__);
-			} zend_catch {
-				fprintf(stderr, "ap_add_common_vars trapped (%u)\n", __LINE__);
-			} zend_end_try();
-			return FAILURE;
-                }
-		zend_end_try();
-#endif
 		ap_add_cgi_vars(r);
 	}
 zend_first_try {


### PR DESCRIPTION
No need to rush out a new build.  I have another idea to implement.