### PR TITLE
Revert "It appears that the libc getenv, putenv, unsetenv and friends…

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -3505,14 +3505,7 @@ static void php_putenv_destructor(zval *zv) /* {{{ */
 		 * We try to avoid this by setting our own value first */
 		SetEnvironmentVariable(pe->key, "bugbug");
 # endif
-		// 2023-02-09 SHL libc getenv/putenv/unsetenv not thread safe
-#		ifdef __OS2__
-		tsrm_env_lock();
-#		endif
 		putenv(pe->previous_value);
-#		ifdef __OS2__
-		tsrm_env_unlock();
-#		endif
 # if defined(PHP_WIN32)
 		efree(pe->previous_value);
 # endif
@@ -3534,14 +3527,7 @@ static void php_putenv_destructor(zval *zv) /* {{{ */
 			pe_ok = FALSE;
 		}
 		else {
-			// 2023-02-09 SHL libc getenv/putenv/unsetenv not thread safe
-#			ifdef __OS2__
-			tsrm_env_lock();
-#			endif
 			unsetenv(pe->key);
-#			ifdef __OS2__
-			tsrm_env_unlock();
-#			endif
 			pe_ok = TRUE;
 		}
 # endif // __OS2__


### PR DESCRIPTION
… are not thread safe."

PHP_RSHUTDOWN_FUNCTION(basic) calls tsrm_env_lock, so the call to tsrm_env_lock in php_putenv_destructor fixes nothing and triggers a recursive mutex deadlock abort.  We need a different solution.

This reverts commit be8693cea3d62e5fadcdc7d27b6682f1721fc1d3.