### PR TITLE
Add more exception avoidance logic to apr callbacks that run on threa…

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -3478,8 +3478,9 @@ zend_module_entry basic_functions_module = { /* {{{ */
    We are still looking for what is doing this
    We use this function to to avoid attempting to access uncommitted memory
    2023-02-06 SHL 
+   2023-02-25 SHL Make public
 */
-static BOOL is_os2_mem_accessible(PVOID pv)
+BOOL is_os2_mem_accessible(PVOID pv)
 {
 	ULONG cb;
 	ULONG flags;

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -452,6 +452,8 @@ static int php_pre_config(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp
 # // 2022-03-16 SHL avoid warnings
 # if defined(__OS2__)
 extern TSRM_API void os2_tsrmls_cache_update();
+// 2023-02-25 SHL Added
+extern void format_httpd_os2_timestamp(char* szTimestamp);
 # endif
 
 
@@ -507,7 +509,14 @@ php_apache_server_startup(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp
 	// 2022-03-14 SHL if startup failed, tell the world
 	if (err != OK) {
 		// 2022-03-16 SHL FIXME to be sure this is really needed
-		apr_pool_cleanup_register(pconf, NULL, php_apache_server_shutdown, apr_pool_cleanup_null);
+		// 2023-02-25 SHL Let's try not registering this
+		// apr_pool_cleanup_register(pconf, NULL, php_apache_server_shutdown, apr_pool_cleanup_null);
+		// 2023-02-25 SHL Let's report to httpd error log or console
+		pid_t pid = _getpid();
+		char szTimestamp[28];
+		format_httpd_os2_timestamp(szTimestamp);
+		fprintf(stderr, "\n%s php_apache_server_startup failed with error %u pid:%u (%x) tid:%u (%u)\n",
+			szTimestamp, err, pid, pid, _gettid(), __LINE__);
 		return err;
 	}
 #else


### PR DESCRIPTION
…d 1.

Try to avoid exception in zend_cleanup_internal_class_data referencing inaccessible CE_STATIC_MEMBERS(ce). Document when the registered php_apache_server_shutdown and php_apache_child_shutdown callbacks are supposed to run on thread 1. Make is_os2_mem_accessible an external function.
Make format_httpd_os2_timestamp an external function.